### PR TITLE
Enhance ministry details with typed schedule summaries

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,3 @@
+# Copie este arquivo para .env e atualize as variáveis conforme necessário
+DATABASE_URL="mysql://usuario:senha@localhost:3306/sistema_escala"
+PORT=3333

--- a/backend/.eslintrc.cjs
+++ b/backend/.eslintrc.cjs
@@ -1,0 +1,31 @@
+module.exports = {
+  env: {
+    node: true,
+    es2021: true,
+  },
+  extends: [
+    'eslint:recommended',
+    'plugin:import/recommended',
+    'plugin:import/typescript',
+    'prettier',
+  ],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint', 'simple-import-sort'],
+  rules: {
+    'simple-import-sort/imports': 'error',
+    'simple-import-sort/exports': 'error',
+    'import/order': 'off',
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+  },
+  settings: {
+    'import/resolver': {
+      typescript: {
+        project: './tsconfig.json',
+      },
+    },
+  },
+};

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,4 @@
+/node_modules
+/dist
+/.env
+/prisma/dev.db

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,72 @@
+# Sistema de Escala - Backend
+
+Este diretório contém uma sugestão de backend em Node.js/TypeScript para ser usado em conjunto com o frontend deste repositório. Caso deseje mantê-lo em um repositório separado, basta copiar o conteúdo da pasta `backend/` para um novo projeto Git e prosseguir com as instruções abaixo.
+
+## Tecnologias
+
+- [Node.js](https://nodejs.org/) + [TypeScript](https://www.typescriptlang.org/)
+- [Express](https://expressjs.com/)
+- [Prisma ORM](https://www.prisma.io/) com banco de dados MySQL
+- [Zod](https://github.com/colinhacks/zod) para validação
+
+## Requisitos
+
+- Node.js 18+
+- Banco de dados MySQL acessível
+
+## Configuração do projeto
+
+1. Copie o arquivo `.env.example` para `.env` e ajuste a variável `DATABASE_URL` para apontar para sua instância MySQL:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+2. Instale as dependências:
+
+   ```bash
+   npm install
+   ```
+
+3. Gere o client do Prisma e aplique as migrações (ajuste o nome da migração conforme desejar):
+
+   ```bash
+   npx prisma migrate dev --name init
+   ```
+
+4. Rode o servidor em ambiente de desenvolvimento:
+
+   ```bash
+   npm run dev
+   ```
+
+   O servidor ficará disponível em `http://localhost:3333` por padrão e expõe todos os endpoints sob o prefixo `/api`.
+
+## Estrutura de rotas principais
+
+| Método | Rota | Descrição |
+| ------ | ---- | --------- |
+| `GET` | `/api/users` | Lista usuários |
+| `POST` | `/api/users` | Cria usuário (voluntário ou coordenador) |
+| `GET` | `/api/ministries` | Lista ministérios |
+| `POST` | `/api/ministries` | Cria ministério |
+| `GET` | `/api/schedules` | Lista escalas |
+| `POST` | `/api/schedules` | Cria nova escala |
+| `PUT` | `/api/schedules/:scheduleId/volunteers/:volunteerId/status` | Atualiza status de participação de voluntário |
+| `GET` | `/api/trade-requests` | Lista pedidos de troca |
+| `POST` | `/api/trade-requests` | Cria pedido de troca |
+| `PUT` | `/api/trade-requests/:id/status` | Atualiza status de pedido de troca |
+| `GET` | `/api/reports` | Lista relatórios gerados |
+| `POST` | `/api/reports` | Gera e salva novo relatório |
+
+## Integração com o frontend
+
+- O backend trabalha com os mesmos formatos de dados definidos em `src/types/index.ts` do frontend, fazendo automaticamente a conversão entre os enums utilizados pelo Prisma e as strings exibidas na interface.
+- Utilize o arquivo `DATABASE_URL` para apontar para o banco de dados da sua aplicação. O Prisma criará e manterá as tabelas necessárias conforme o schema definido em `prisma/schema.prisma`.
+- Para executar em produção, rode `npm run build` e depois `npm start`.
+
+## Próximos passos sugeridos
+
+- Implementar autenticação (JWT) para proteger os endpoints.
+- Adicionar testes automatizados.
+- Configurar CI/CD e pipeline de deploy.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "sistema-escala-backend",
+  "version": "1.0.0",
+  "description": "Backend API para o Sistema de Escala utilizando MySQL",
+  "main": "dist/server.js",
+  "scripts": {
+    "dev": "ts-node-dev --respawn --transpile-only src/server.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/server.js",
+    "lint": "eslint . --ext .ts",
+    "prisma:migrate": "prisma migrate dev",
+    "prisma:generate": "prisma generate"
+  },
+  "keywords": ["escala", "igreja", "api", "mysql"],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@prisma/client": "^5.8.0",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.0",
+    "express": "^4.18.2",
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.11.17",
+    "@typescript-eslint/eslint-plugin": "^6.19.0",
+    "@typescript-eslint/parser": "^6.19.0",
+    "eslint": "^8.56.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-simple-import-sort": "^10.0.0",
+    "prisma": "^5.8.0",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,0 +1,137 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "mysql"
+  url      = env("DATABASE_URL")
+}
+
+enum UserType {
+  COORDINATOR
+  VOLUNTEER
+}
+
+enum ScheduleStatus {
+  PENDING
+  CONFIRMED
+  TRADE_REQUESTED
+}
+
+enum TradeRequestStatus {
+  PENDING
+  APPROVED
+  REJECTED
+}
+
+enum ReportType {
+  SCHEDULE_SUMMARY
+  VOLUNTEER_STATUS
+  MINISTRY_REPORT
+}
+
+model User {
+  id         String     @id @default(uuid())
+  name       String
+  email      String     @unique
+  phone      String
+  cpf        String     @unique
+  rg         String
+  password   String
+  userType   UserType
+  createdAt  DateTime   @default(now())
+  updatedAt  DateTime   @updatedAt
+  address    Address?
+  ministries VolunteerMinistry[]
+  schedulesCreated Schedule[] @relation("ScheduleCreatedBy")
+  volunteerAssignments ScheduleVolunteer[]
+  tradeRequests TradeRequest[] @relation("TradeRequestRequester")
+  respondedTradeRequests TradeRequest[] @relation("TradeRequestResponder")
+  reports    Report[]   @relation("ReportGeneratedBy")
+}
+
+model Address {
+  id          String @id @default(uuid())
+  street      String
+  number      String
+  complement  String?
+  neighborhood String
+  city        String
+  state       String
+  zipCode     String
+  user        User   @relation(fields: [userId], references: [id])
+  userId      String @unique
+}
+
+model Ministry {
+  id          String   @id @default(uuid())
+  name        String
+  description String
+  color       String
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  volunteers  VolunteerMinistry[]
+  schedules   Schedule[]
+}
+
+model VolunteerMinistry {
+  volunteerId String
+  ministryId  String
+  assignedAt  DateTime @default(now())
+  volunteer   User     @relation(fields: [volunteerId], references: [id])
+  ministry    Ministry @relation(fields: [ministryId], references: [id])
+
+  @@id([volunteerId, ministryId])
+}
+
+model Schedule {
+  id          String    @id @default(uuid())
+  date        DateTime
+  time        String
+  ministryId  String
+  createdById String
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+  ministry    Ministry  @relation(fields: [ministryId], references: [id])
+  createdBy   User      @relation("ScheduleCreatedBy", fields: [createdById], references: [id])
+  volunteers  ScheduleVolunteer[]
+  tradeRequests TradeRequest[]
+}
+
+model ScheduleVolunteer {
+  scheduleId String
+  volunteerId String
+  status      ScheduleStatus @default(PENDING)
+  confirmedAt DateTime?
+  requestedChangeAt DateTime?
+  requestedChangeReason String?
+  volunteer  User     @relation(fields: [volunteerId], references: [id])
+  schedule   Schedule @relation(fields: [scheduleId], references: [id])
+
+  @@id([scheduleId, volunteerId])
+}
+
+model TradeRequest {
+  id                     String             @id @default(uuid())
+  scheduleId             String
+  requestingVolunteerId  String
+  reason                 String
+  status                 TradeRequestStatus @default(PENDING)
+  createdAt              DateTime           @default(now())
+  respondedAt            DateTime?
+  respondedById          String?
+  schedule               Schedule           @relation(fields: [scheduleId], references: [id])
+  requestingVolunteer    User               @relation("TradeRequestRequester", fields: [requestingVolunteerId], references: [id])
+  respondedBy            User?              @relation("TradeRequestResponder", fields: [respondedById], references: [id])
+}
+
+model Report {
+  id             String     @id @default(uuid())
+  type           ReportType
+  dateRangeStart DateTime
+  dateRangeEnd   DateTime
+  data           Json
+  generatedById  String
+  generatedAt    DateTime @default(now())
+  generatedBy    User     @relation("ReportGeneratedBy", fields: [generatedById], references: [id])
+}

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,0 +1,14 @@
+import cors from 'cors';
+import express from 'express';
+
+import routes from './routes';
+import { errorHandler } from './middlewares/errorHandler';
+
+const app = express();
+
+app.use(cors());
+app.use(express.json());
+app.use('/api', routes);
+app.use(errorHandler);
+
+export default app;

--- a/backend/src/config/prisma.ts
+++ b/backend/src/config/prisma.ts
@@ -1,0 +1,3 @@
+import { PrismaClient } from '@prisma/client';
+
+export const prisma = new PrismaClient();

--- a/backend/src/controllers/ministriesController.ts
+++ b/backend/src/controllers/ministriesController.ts
@@ -1,0 +1,177 @@
+import { NextFunction, Request, Response } from 'express';
+
+import { ScheduleStatus, TradeRequestStatus } from '@prisma/client';
+
+import { prisma } from '../config/prisma';
+import { mapMinistryToResponse } from '../utils/mappers';
+import { createMinistrySchema, updateMinistrySchema } from '../validators/ministryValidator';
+
+export const listMinistries = async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const ministries = await prisma.ministry.findMany({
+      include: { volunteers: true },
+      orderBy: { name: 'asc' },
+    });
+
+    res.json({ success: true, data: ministries.map(mapMinistryToResponse) });
+  } catch (error) {
+    next(error);
+  }
+};
+
+type MinistryScheduleSummary = {
+  id: string;
+  date: Date;
+  time: string;
+  totalVolunteers: number;
+  statusCount: Record<'pending' | 'confirmed' | 'tradeRequested', number>;
+  pendingTradeRequests: number;
+};
+
+type MinistryOverview = {
+  totalSchedules: number;
+  totalVolunteersAssigned: number;
+  pendingConfirmations: number;
+  pendingTradeRequests: number;
+};
+
+const getScheduleSummary = (schedule: {
+  id: string;
+  date: Date;
+  time: string;
+  volunteers: {
+    status: ScheduleStatus;
+  }[];
+  tradeRequests: {
+    status: TradeRequestStatus;
+  }[];
+}): MinistryScheduleSummary => {
+  const statusCount = schedule.volunteers.reduce<
+    Record<'pending' | 'confirmed' | 'tradeRequested', number>
+  >(
+    (accumulator, current) => {
+      if (current.status === ScheduleStatus.PENDING) {
+        accumulator.pending += 1;
+      } else if (current.status === ScheduleStatus.CONFIRMED) {
+        accumulator.confirmed += 1;
+      } else if (current.status === ScheduleStatus.TRADE_REQUESTED) {
+        accumulator.tradeRequested += 1;
+      }
+
+      return accumulator;
+    },
+    { pending: 0, confirmed: 0, tradeRequested: 0 }
+  );
+
+  const pendingTradeRequests = schedule.tradeRequests.filter(
+    (request) => request.status === TradeRequestStatus.PENDING
+  ).length;
+
+  return {
+    id: schedule.id,
+    date: schedule.date,
+    time: schedule.time,
+    totalVolunteers: schedule.volunteers.length,
+    statusCount,
+    pendingTradeRequests,
+  };
+};
+
+const buildOverview = (summaries: MinistryScheduleSummary[]): MinistryOverview =>
+  summaries.reduce<MinistryOverview>(
+    (totals, summary) => ({
+      totalSchedules: totals.totalSchedules + 1,
+      totalVolunteersAssigned: totals.totalVolunteersAssigned + summary.totalVolunteers,
+      pendingConfirmations: totals.pendingConfirmations + summary.statusCount.pending,
+      pendingTradeRequests: totals.pendingTradeRequests + summary.pendingTradeRequests,
+    }),
+    {
+      totalSchedules: 0,
+      totalVolunteersAssigned: 0,
+      pendingConfirmations: 0,
+      pendingTradeRequests: 0,
+    }
+  );
+
+export const getMinistry = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const ministry = await prisma.ministry.findUnique({
+      where: { id: req.params.id },
+      include: {
+        volunteers: true,
+        schedules: {
+          include: {
+            volunteers: true,
+            tradeRequests: true,
+          },
+          orderBy: { date: 'asc' },
+        },
+      },
+    });
+
+    if (!ministry) {
+      return res.status(404).json({ success: false, message: 'Ministério não encontrado' });
+    }
+
+    const scheduleSummaries = ministry.schedules.map((schedule) =>
+      getScheduleSummary(schedule)
+    );
+    const overview = buildOverview(scheduleSummaries);
+
+    res.json({
+      success: true,
+      data: {
+        ...mapMinistryToResponse(ministry),
+        overview: {
+          totalSchedules: overview.totalSchedules,
+          totalVolunteersAssigned: overview.totalVolunteersAssigned,
+          pendingConfirmations: overview.pendingConfirmations,
+          pendingTradeRequests: overview.pendingTradeRequests,
+        },
+        schedules: scheduleSummaries,
+      },
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const createMinistry = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const payload = createMinistrySchema.parse(req.body);
+
+    const ministry = await prisma.ministry.create({
+      data: payload,
+      include: { volunteers: true },
+    });
+
+    res.status(201).json({ success: true, data: mapMinistryToResponse(ministry) });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const updateMinistry = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const payload = updateMinistrySchema.parse(req.body);
+
+    const ministry = await prisma.ministry.update({
+      where: { id: req.params.id },
+      data: payload,
+      include: { volunteers: true },
+    });
+
+    res.json({ success: true, data: mapMinistryToResponse(ministry) });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const deleteMinistry = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    await prisma.ministry.delete({ where: { id: req.params.id } });
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/src/controllers/reportsController.ts
+++ b/backend/src/controllers/reportsController.ts
@@ -1,0 +1,196 @@
+import { NextFunction, Request, Response } from 'express';
+
+import { UserType } from '@prisma/client';
+
+import { prisma } from '../config/prisma';
+import { mapReportToResponse } from '../utils/mappers';
+import { reportTypeToPrisma } from '../utils/statusMapper';
+import { generateReportSchema } from '../validators/reportValidator';
+
+const reportsInclude = {
+  generatedBy: true,
+};
+
+export const listReports = async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const reports = await prisma.report.findMany({
+      include: reportsInclude,
+      orderBy: { generatedAt: 'desc' },
+    });
+
+    res.json({ success: true, data: reports.map(mapReportToResponse) });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const generateReport = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const payload = generateReportSchema.parse(req.body);
+
+    const startDate = new Date(payload.dateRange.start);
+    const endDate = new Date(payload.dateRange.end);
+
+    if (startDate > endDate) {
+      return res.status(400).json({ success: false, message: 'Período inválido' });
+    }
+
+    const coordinator = await prisma.user.findUnique({ where: { id: payload.generatedBy } });
+
+    if (!coordinator || coordinator.userType !== UserType.COORDINATOR) {
+      return res.status(400).json({ success: false, message: 'Apenas coordenadores podem gerar relatórios' });
+    }
+
+    let data: unknown;
+
+    switch (payload.type) {
+      case 'schedule-summary':
+        data = await buildScheduleSummary(startDate, endDate);
+        break;
+      case 'volunteer-status':
+        data = await buildVolunteerStatusReport(startDate, endDate);
+        break;
+      case 'ministry-report':
+        data = await buildMinistryReport(startDate, endDate);
+        break;
+      default:
+        return res.status(400).json({ success: false, message: 'Tipo de relatório inválido' });
+    }
+
+    const report = await prisma.report.create({
+      data: {
+        type: reportTypeToPrisma[payload.type],
+        dateRangeStart: startDate,
+        dateRangeEnd: endDate,
+        data,
+        generatedById: payload.generatedBy,
+      },
+      include: reportsInclude,
+    });
+
+    res.status(201).json({ success: true, data: mapReportToResponse(report) });
+  } catch (error) {
+    next(error);
+  }
+};
+
+const buildScheduleSummary = async (startDate: Date, endDate: Date) => {
+  const schedules = await prisma.schedule.findMany({
+    where: { date: { gte: startDate, lte: endDate } },
+    include: {
+      ministry: true,
+      volunteers: true,
+    },
+  });
+
+  const totalSchedules = schedules.length;
+
+  const byMinistry = schedules.reduce<Record<string, { ministryName: string; total: number }>>(
+    (accumulator, schedule) => {
+      const ministryId = schedule.ministryId;
+      const ministryName = schedule.ministry.name;
+      if (!accumulator[ministryId]) {
+        accumulator[ministryId] = { ministryName, total: 0 };
+      }
+      accumulator[ministryId].total += 1;
+      return accumulator;
+    },
+    {},
+  );
+
+  const volunteerAssignments = schedules.reduce((total, schedule) => total + schedule.volunteers.length, 0);
+
+  return {
+    totalSchedules,
+    volunteerAssignments,
+    ministries: Object.entries(byMinistry).map(([id, info]) => ({
+      ministryId: id,
+      ministryName: info.ministryName,
+      schedules: info.total,
+    })),
+  };
+};
+
+const buildVolunteerStatusReport = async (startDate: Date, endDate: Date) => {
+  const volunteers = await prisma.scheduleVolunteer.findMany({
+    where: {
+      schedule: {
+        date: { gte: startDate, lte: endDate },
+      },
+    },
+    include: {
+      volunteer: true,
+    },
+  });
+
+  const grouped = volunteers.reduce<Record<
+    string,
+    {
+      volunteerName: string;
+      pending: number;
+      confirmed: number;
+      requestedChange: number;
+    }
+  >>((accumulator, current) => {
+    const existing = accumulator[current.volunteerId];
+    if (!existing) {
+      accumulator[current.volunteerId] = {
+        volunteerName: current.volunteer.name,
+        pending: 0,
+        confirmed: 0,
+        requestedChange: 0,
+      };
+    }
+
+    const record = accumulator[current.volunteerId];
+
+    switch (current.status) {
+      case 'PENDING':
+        record.pending += 1;
+        break;
+      case 'CONFIRMED':
+        record.confirmed += 1;
+        break;
+      case 'TRADE_REQUESTED':
+        record.requestedChange += 1;
+        break;
+      default:
+        break;
+    }
+
+    return accumulator;
+  }, {});
+
+  return Object.entries(grouped).map(([volunteerId, info]) => ({
+    volunteerId,
+    volunteerName: info.volunteerName,
+    pending: info.pending,
+    confirmed: info.confirmed,
+    requestedChange: info.requestedChange,
+  }));
+};
+
+const buildMinistryReport = async (startDate: Date, endDate: Date) => {
+  const ministries = await prisma.ministry.findMany({
+    include: {
+      volunteers: true,
+      schedules: {
+        where: { date: { gte: startDate, lte: endDate } },
+        include: { volunteers: true },
+      },
+    },
+  });
+
+  return ministries.map((ministry) => ({
+    ministryId: ministry.id,
+    name: ministry.name,
+    description: ministry.description,
+    totalVolunteers: ministry.volunteers.length,
+    schedules: ministry.schedules.map((schedule) => ({
+      scheduleId: schedule.id,
+      date: schedule.date,
+      time: schedule.time,
+      volunteers: schedule.volunteers.length,
+    })),
+  }));
+};

--- a/backend/src/controllers/schedulesController.ts
+++ b/backend/src/controllers/schedulesController.ts
@@ -1,0 +1,198 @@
+import { NextFunction, Request, Response } from 'express';
+
+import { UserType } from '@prisma/client';
+
+import { prisma } from '../config/prisma';
+import { mapScheduleToResponse } from '../utils/mappers';
+import { scheduleStatusToPrisma } from '../utils/statusMapper';
+import {
+  createScheduleSchema,
+  updateScheduleSchema,
+  updateScheduleStatusSchema,
+} from '../validators/scheduleValidator';
+
+const scheduleInclude = {
+  ministry: true,
+  createdBy: true,
+  volunteers: {
+    include: {
+      volunteer: true,
+    },
+  },
+};
+
+export const listSchedules = async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const schedules = await prisma.schedule.findMany({
+      include: scheduleInclude,
+      orderBy: { date: 'desc' },
+    });
+
+    res.json({ success: true, data: schedules.map(mapScheduleToResponse) });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const getSchedule = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const schedule = await prisma.schedule.findUnique({
+      where: { id: req.params.id },
+      include: scheduleInclude,
+    });
+
+    if (!schedule) {
+      return res.status(404).json({ success: false, message: 'Escala não encontrada' });
+    }
+
+    res.json({ success: true, data: mapScheduleToResponse(schedule) });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const createSchedule = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const payload = createScheduleSchema.parse(req.body);
+
+    const [coordinator, volunteers, ministry] = await Promise.all([
+      prisma.user.findUnique({ where: { id: payload.createdBy } }),
+      prisma.user.findMany({
+        where: { id: { in: payload.volunteerIds }, userType: UserType.VOLUNTEER },
+      }),
+      prisma.ministry.findUnique({ where: { id: payload.ministryId } }),
+    ]);
+
+    if (!ministry) {
+      return res.status(404).json({ success: false, message: 'Ministério não encontrado' });
+    }
+
+    if (!coordinator || coordinator.userType !== UserType.COORDINATOR) {
+      return res.status(400).json({ success: false, message: 'Coordenador inválido' });
+    }
+
+    if (volunteers.length !== payload.volunteerIds.length) {
+      return res.status(400).json({ success: false, message: 'Lista de voluntários inválida' });
+    }
+
+    const schedule = await prisma.schedule.create({
+      data: {
+        date: payload.date,
+        time: payload.time,
+        ministryId: payload.ministryId,
+        createdById: payload.createdBy,
+        volunteers: {
+          create: payload.volunteerIds.map((volunteerId) => ({ volunteerId })),
+        },
+      },
+      include: scheduleInclude,
+    });
+
+    res.status(201).json({ success: true, data: mapScheduleToResponse(schedule) });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const updateSchedule = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const payload = updateScheduleSchema.parse(req.body);
+
+    const existingSchedule = await prisma.schedule.findUnique({
+      where: { id: req.params.id },
+    });
+
+    if (!existingSchedule) {
+      return res.status(404).json({ success: false, message: 'Escala não encontrada' });
+    }
+
+    if (payload.volunteerIds) {
+      const volunteers = await prisma.user.findMany({
+        where: { id: { in: payload.volunteerIds }, userType: UserType.VOLUNTEER },
+      });
+
+      if (volunteers.length !== payload.volunteerIds.length) {
+        return res.status(400).json({ success: false, message: 'Lista de voluntários inválida' });
+      }
+    }
+
+    if (payload.ministryId) {
+      const ministry = await prisma.ministry.findUnique({ where: { id: payload.ministryId } });
+      if (!ministry) {
+        return res.status(404).json({ success: false, message: 'Ministério não encontrado' });
+      }
+    }
+
+    const schedule = await prisma.schedule.update({
+      where: { id: req.params.id },
+      data: {
+        date: payload.date ?? undefined,
+        time: payload.time,
+        ministryId: payload.ministryId,
+        volunteers: payload.volunteerIds
+          ? {
+              deleteMany: { scheduleId: req.params.id },
+              create: payload.volunteerIds.map((volunteerId) => ({ volunteerId })),
+            }
+          : undefined,
+      },
+      include: scheduleInclude,
+    });
+
+    res.json({ success: true, data: mapScheduleToResponse(schedule) });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const deleteSchedule = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    await prisma.schedule.delete({ where: { id: req.params.id } });
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const updateScheduleVolunteerStatus = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const payload = updateScheduleStatusSchema.parse(req.body);
+    const { scheduleId, volunteerId } = req.params;
+
+    await prisma.scheduleVolunteer.update({
+      where: {
+        scheduleId_volunteerId: {
+          scheduleId,
+          volunteerId,
+        },
+      },
+      data: {
+        status: scheduleStatusToPrisma[payload.status],
+        confirmedAt: payload.status === 'confirmado' ? new Date() : null,
+        requestedChangeAt: payload.status === 'troca-solicitada' ? new Date() : null,
+        requestedChangeReason:
+          payload.status === 'troca-solicitada' ? payload.requestedChangeReason ?? null : null,
+      },
+      include: {
+        schedule: scheduleInclude,
+      },
+    });
+
+    const schedule = await prisma.schedule.findUnique({
+      where: { id: scheduleId },
+      include: scheduleInclude,
+    });
+
+    if (!schedule) {
+      return res.status(404).json({ success: false, message: 'Escala não encontrada' });
+    }
+
+    res.json({ success: true, data: mapScheduleToResponse(schedule) });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/src/controllers/tradeRequestsController.ts
+++ b/backend/src/controllers/tradeRequestsController.ts
@@ -1,0 +1,110 @@
+import { NextFunction, Request, Response } from 'express';
+
+import { prisma } from '../config/prisma';
+import { mapTradeRequestToResponse } from '../utils/mappers';
+import { tradeStatusToPrisma } from '../utils/statusMapper';
+import {
+  createTradeRequestSchema,
+  updateTradeRequestStatusSchema,
+} from '../validators/tradeRequestValidator';
+
+const tradeRequestInclude = {
+  schedule: {
+    include: {
+      ministry: true,
+    },
+  },
+  requestingVolunteer: true,
+  respondedBy: true,
+};
+
+export const listTradeRequests = async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const tradeRequests = await prisma.tradeRequest.findMany({
+      include: tradeRequestInclude,
+      orderBy: { createdAt: 'desc' },
+    });
+
+    res.json({ success: true, data: tradeRequests.map(mapTradeRequestToResponse) });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const createTradeRequest = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const payload = createTradeRequestSchema.parse(req.body);
+
+    const [schedule, volunteer, assignment] = await Promise.all([
+      prisma.schedule.findUnique({ where: { id: payload.scheduleId } }),
+      prisma.user.findUnique({ where: { id: payload.requestingVolunteerId } }),
+      prisma.scheduleVolunteer.findUnique({
+        where: {
+          scheduleId_volunteerId: {
+            scheduleId: payload.scheduleId,
+            volunteerId: payload.requestingVolunteerId,
+          },
+        },
+      }),
+    ]);
+
+    if (!schedule) {
+      return res.status(404).json({ success: false, message: 'Escala não encontrada' });
+    }
+
+    if (!assignment) {
+      return res.status(400).json({ success: false, message: 'Voluntário não está escalado para esta escala' });
+    }
+
+    if (!volunteer) {
+      return res.status(404).json({ success: false, message: 'Voluntário não encontrado' });
+    }
+
+    const tradeRequest = await prisma.tradeRequest.create({
+      data: {
+        scheduleId: payload.scheduleId,
+        requestingVolunteerId: payload.requestingVolunteerId,
+        reason: payload.reason,
+      },
+      include: tradeRequestInclude,
+    });
+
+    res.status(201).json({ success: true, data: mapTradeRequestToResponse(tradeRequest) });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const updateTradeRequestStatus = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const payload = updateTradeRequestStatusSchema.parse(req.body);
+
+    const coordinator = await prisma.user.findUnique({ where: { id: payload.respondedBy } });
+
+    if (!coordinator) {
+      return res.status(404).json({ success: false, message: 'Coordenador não encontrado' });
+    }
+
+    if (coordinator.userType !== 'COORDINATOR') {
+      return res.status(400).json({ success: false, message: 'Apenas coordenadores podem responder trocas' });
+    }
+
+    const tradeRequest = await prisma.tradeRequest.update({
+      where: { id: req.params.id },
+      data: {
+        status: tradeStatusToPrisma[payload.status],
+        respondedById: payload.respondedBy,
+        respondedAt: new Date(),
+      },
+      include: tradeRequestInclude,
+    });
+
+    res.json({ success: true, data: mapTradeRequestToResponse(tradeRequest) });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/src/controllers/usersController.ts
+++ b/backend/src/controllers/usersController.ts
@@ -1,0 +1,168 @@
+import { NextFunction, Request, Response } from 'express';
+
+import { prisma } from '../config/prisma';
+import { mapUserToResponse } from '../utils/mappers';
+import { userTypeToFront, userTypeToPrisma } from '../utils/statusMapper';
+import { createUserSchema, updateUserSchema } from '../validators/userValidator';
+
+export const listUsers = async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const users = await prisma.user.findMany({
+      include: {
+        address: true,
+        ministries: { include: { ministry: true } },
+      },
+      orderBy: { name: 'asc' },
+    });
+
+    res.json({ success: true, data: users.map(mapUserToResponse) });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const getUser = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const user = await prisma.user.findUnique({
+      where: { id: req.params.id },
+      include: {
+        address: true,
+        ministries: { include: { ministry: true } },
+      },
+    });
+
+    if (!user) {
+      return res.status(404).json({ success: false, message: 'Usuário não encontrado' });
+    }
+
+    res.json({ success: true, data: mapUserToResponse(user) });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const createUser = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const payload = createUserSchema.parse(req.body);
+
+    const user = await prisma.user.create({
+      data: {
+        name: payload.name,
+        email: payload.email,
+        phone: payload.phone,
+        cpf: payload.cpf,
+        rg: payload.rg,
+        password: payload.password,
+        userType: userTypeToPrisma[payload.userType],
+        address: payload.address
+          ? {
+              create: {
+                street: payload.address.street,
+                number: payload.address.number,
+                complement: payload.address.complement,
+                neighborhood: payload.address.neighborhood,
+                city: payload.address.city,
+                state: payload.address.state,
+                zipCode: payload.address.zipCode,
+              },
+            }
+          : undefined,
+        ministries:
+          payload.userType === 'volunteer'
+            ? {
+                create: payload.ministries.map((ministryId) => ({ ministryId })),
+              }
+            : undefined,
+      },
+      include: {
+        address: true,
+        ministries: { include: { ministry: true } },
+      },
+    });
+
+    res.status(201).json({ success: true, data: mapUserToResponse(user) });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const updateUser = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const payload = updateUserSchema.parse(req.body);
+
+    const existingUser = await prisma.user.findUnique({
+      where: { id: req.params.id },
+      include: { address: true },
+    });
+
+    if (!existingUser) {
+      return res.status(404).json({ success: false, message: 'Usuário não encontrado' });
+    }
+
+    const updatedUserType = payload.userType ?? userTypeToFront[existingUser.userType];
+
+    const user = await prisma.user.update({
+      where: { id: req.params.id },
+      data: {
+        name: payload.name,
+        email: payload.email,
+        phone: payload.phone,
+        cpf: payload.cpf,
+        rg: payload.rg,
+        password: payload.password,
+        userType: payload.userType ? userTypeToPrisma[payload.userType] : undefined,
+        address: payload.address
+          ? existingUser.address
+            ? {
+                update: {
+                  street: payload.address.street,
+                  number: payload.address.number,
+                  complement: payload.address.complement,
+                  neighborhood: payload.address.neighborhood,
+                  city: payload.address.city,
+                  state: payload.address.state,
+                  zipCode: payload.address.zipCode,
+                },
+              }
+            : {
+                create: {
+                  street: payload.address.street,
+                  number: payload.address.number,
+                  complement: payload.address.complement,
+                  neighborhood: payload.address.neighborhood,
+                  city: payload.address.city,
+                  state: payload.address.state,
+                  zipCode: payload.address.zipCode,
+                },
+              }
+          : undefined,
+        ministries:
+          payload.ministries && updatedUserType === 'volunteer'
+            ? {
+                deleteMany: { volunteerId: req.params.id },
+                create: payload.ministries.map((ministryId) => ({ ministryId })),
+              }
+            : payload.ministries && updatedUserType !== 'volunteer'
+            ? { deleteMany: { volunteerId: req.params.id } }
+            : undefined,
+      },
+      include: {
+        address: true,
+        ministries: { include: { ministry: true } },
+      },
+    });
+
+    res.json({ success: true, data: mapUserToResponse(user) });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const deleteUser = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    await prisma.user.delete({ where: { id: req.params.id } });
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/src/middlewares/errorHandler.ts
+++ b/backend/src/middlewares/errorHandler.ts
@@ -1,0 +1,33 @@
+import { NextFunction, Request, Response } from 'express';
+import { ZodError } from 'zod';
+
+export const errorHandler = (error: unknown, _req: Request, res: Response, _next: NextFunction) => {
+  if (error instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: 'Erro de validação',
+      errors: error.errors.map((err) => ({
+        field: err.path.join('.'),
+        message: err.message,
+      })),
+    });
+  }
+
+  if (error instanceof Error) {
+    if ('code' in error) {
+      const prismaCode = (error as { code?: string }).code;
+
+      if (prismaCode === 'P2002') {
+        return res.status(409).json({ success: false, message: 'Registro duplicado' });
+      }
+
+      if (prismaCode === 'P2025') {
+        return res.status(404).json({ success: false, message: 'Registro não encontrado' });
+      }
+    }
+
+    return res.status(500).json({ success: false, message: error.message });
+  }
+
+  return res.status(500).json({ success: false, message: 'Erro desconhecido' });
+};

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -1,0 +1,17 @@
+import { Router } from 'express';
+
+import ministriesRouter from './ministries';
+import reportsRouter from './reports';
+import schedulesRouter from './schedules';
+import tradeRequestsRouter from './tradeRequests';
+import usersRouter from './users';
+
+const router = Router();
+
+router.use('/users', usersRouter);
+router.use('/ministries', ministriesRouter);
+router.use('/schedules', schedulesRouter);
+router.use('/trade-requests', tradeRequestsRouter);
+router.use('/reports', reportsRouter);
+
+export default router;

--- a/backend/src/routes/ministries.ts
+++ b/backend/src/routes/ministries.ts
@@ -1,0 +1,19 @@
+import { Router } from 'express';
+
+import {
+  createMinistry,
+  deleteMinistry,
+  getMinistry,
+  listMinistries,
+  updateMinistry,
+} from '../controllers/ministriesController';
+
+const router = Router();
+
+router.get('/', listMinistries);
+router.get('/:id', getMinistry);
+router.post('/', createMinistry);
+router.put('/:id', updateMinistry);
+router.delete('/:id', deleteMinistry);
+
+export default router;

--- a/backend/src/routes/reports.ts
+++ b/backend/src/routes/reports.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+
+import { generateReport, listReports } from '../controllers/reportsController';
+
+const router = Router();
+
+router.get('/', listReports);
+router.post('/', generateReport);
+
+export default router;

--- a/backend/src/routes/schedules.ts
+++ b/backend/src/routes/schedules.ts
@@ -1,0 +1,21 @@
+import { Router } from 'express';
+
+import {
+  createSchedule,
+  deleteSchedule,
+  getSchedule,
+  listSchedules,
+  updateSchedule,
+  updateScheduleVolunteerStatus,
+} from '../controllers/schedulesController';
+
+const router = Router();
+
+router.get('/', listSchedules);
+router.get('/:id', getSchedule);
+router.post('/', createSchedule);
+router.put('/:id', updateSchedule);
+router.delete('/:id', deleteSchedule);
+router.put('/:scheduleId/volunteers/:volunteerId/status', updateScheduleVolunteerStatus);
+
+export default router;

--- a/backend/src/routes/tradeRequests.ts
+++ b/backend/src/routes/tradeRequests.ts
@@ -1,0 +1,15 @@
+import { Router } from 'express';
+
+import {
+  createTradeRequest,
+  listTradeRequests,
+  updateTradeRequestStatus,
+} from '../controllers/tradeRequestsController';
+
+const router = Router();
+
+router.get('/', listTradeRequests);
+router.post('/', createTradeRequest);
+router.put('/:id/status', updateTradeRequestStatus);
+
+export default router;

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -1,0 +1,13 @@
+import { Router } from 'express';
+
+import { createUser, deleteUser, getUser, listUsers, updateUser } from '../controllers/usersController';
+
+const router = Router();
+
+router.get('/', listUsers);
+router.get('/:id', getUser);
+router.post('/', createUser);
+router.put('/:id', updateUser);
+router.delete('/:id', deleteUser);
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,0 +1,9 @@
+import 'dotenv/config';
+
+import app from './app';
+
+const PORT = process.env.PORT || 3333;
+
+app.listen(PORT, () => {
+  console.log(`🚀 Servidor rodando na porta ${PORT}`);
+});

--- a/backend/src/utils/mappers.ts
+++ b/backend/src/utils/mappers.ts
@@ -1,0 +1,114 @@
+import {
+  Address,
+  Ministry,
+  Report,
+  Schedule,
+  ScheduleStatus,
+  ScheduleVolunteer,
+  TradeRequest,
+  User,
+  VolunteerMinistry,
+} from '@prisma/client';
+
+import { reportTypeToFront, scheduleStatusToFront, tradeStatusToFront, userTypeToFront } from './statusMapper';
+
+export type UserWithRelations = User & {
+  address?: Address | null;
+  ministries?: (VolunteerMinistry & { ministry: Ministry })[];
+};
+
+export const mapUserToResponse = (user: UserWithRelations) => ({
+  id: user.id,
+  name: user.name,
+  email: user.email,
+  phone: user.phone,
+  cpf: user.cpf,
+  rg: user.rg,
+  userType: userTypeToFront[user.userType],
+  address: user.address
+    ? {
+        street: user.address.street,
+        number: user.address.number,
+        complement: user.address.complement ?? undefined,
+        neighborhood: user.address.neighborhood,
+        city: user.address.city,
+        state: user.address.state,
+        zipCode: user.address.zipCode,
+      }
+    : null,
+  ministries: user.ministries?.map((item) => item.ministryId) ?? [],
+  createdAt: user.createdAt,
+  updatedAt: user.updatedAt,
+});
+
+export type MinistryWithRelations = Ministry & {
+  volunteers?: VolunteerMinistry[];
+};
+
+export const mapMinistryToResponse = (ministry: MinistryWithRelations) => ({
+  id: ministry.id,
+  name: ministry.name,
+  description: ministry.description,
+  color: ministry.color,
+  createdAt: ministry.createdAt,
+  updatedAt: ministry.updatedAt,
+  volunteers: ministry.volunteers?.map((volunteer) => volunteer.volunteerId) ?? [],
+});
+
+export type ScheduleWithRelations = Schedule & {
+  ministry: Ministry;
+  createdBy: User;
+  volunteers: (ScheduleVolunteer & { volunteer: User })[];
+};
+
+export const mapScheduleToResponse = (schedule: ScheduleWithRelations) => ({
+  id: schedule.id,
+  date: schedule.date,
+  time: schedule.time,
+  ministry: schedule.ministryId,
+  volunteers: schedule.volunteers.map((volunteer) => ({
+    volunteerId: volunteer.volunteerId,
+    volunteerName: volunteer.volunteer.name,
+    status: scheduleStatusToFront[volunteer.status as ScheduleStatus],
+    confirmedAt: volunteer.confirmedAt ?? undefined,
+    requestedChangeAt: volunteer.requestedChangeAt ?? undefined,
+    requestedChangeReason: volunteer.requestedChangeReason ?? undefined,
+  })),
+  createdBy: schedule.createdById,
+  createdAt: schedule.createdAt,
+  updatedAt: schedule.updatedAt,
+});
+
+export type TradeRequestWithRelations = TradeRequest & {
+  schedule: Schedule & { ministry: Ministry };
+  requestingVolunteer: User;
+  respondedBy?: User | null;
+};
+
+export const mapTradeRequestToResponse = (tradeRequest: TradeRequestWithRelations) => ({
+  id: tradeRequest.id,
+  scheduleId: tradeRequest.scheduleId,
+  requestingVolunteerId: tradeRequest.requestingVolunteerId,
+  requestingVolunteerName: tradeRequest.requestingVolunteer.name,
+  reason: tradeRequest.reason,
+  status: tradeStatusToFront[tradeRequest.status],
+  createdAt: tradeRequest.createdAt,
+  respondedAt: tradeRequest.respondedAt ?? undefined,
+  respondedBy: tradeRequest.respondedById ?? undefined,
+});
+
+export type ReportWithRelations = Report & {
+  generatedBy: User;
+};
+
+export const mapReportToResponse = (report: ReportWithRelations) => ({
+  id: report.id,
+  type: reportTypeToFront[report.type],
+  dateRange: {
+    start: report.dateRangeStart,
+    end: report.dateRangeEnd,
+  },
+  data: report.data,
+  generatedBy: report.generatedById,
+  generatedAt: report.generatedAt,
+});

--- a/backend/src/utils/statusMapper.ts
+++ b/backend/src/utils/statusMapper.ts
@@ -1,0 +1,57 @@
+import {
+  ReportType,
+  ScheduleStatus,
+  TradeRequestStatus,
+  UserType,
+} from '@prisma/client';
+
+type FrontScheduleStatus = 'pendente' | 'confirmado' | 'troca-solicitada';
+type FrontTradeRequestStatus = 'pending' | 'approved' | 'rejected';
+type FrontReportType = 'schedule-summary' | 'volunteer-status' | 'ministry-report';
+type FrontUserType = 'coordinator' | 'volunteer';
+
+export const scheduleStatusToPrisma: Record<FrontScheduleStatus, ScheduleStatus> = {
+  pendente: ScheduleStatus.PENDING,
+  confirmado: ScheduleStatus.CONFIRMED,
+  'troca-solicitada': ScheduleStatus.TRADE_REQUESTED,
+};
+
+export const scheduleStatusToFront: Record<ScheduleStatus, FrontScheduleStatus> = {
+  [ScheduleStatus.PENDING]: 'pendente',
+  [ScheduleStatus.CONFIRMED]: 'confirmado',
+  [ScheduleStatus.TRADE_REQUESTED]: 'troca-solicitada',
+};
+
+export const tradeStatusToPrisma: Record<FrontTradeRequestStatus, TradeRequestStatus> = {
+  pending: TradeRequestStatus.PENDING,
+  approved: TradeRequestStatus.APPROVED,
+  rejected: TradeRequestStatus.REJECTED,
+};
+
+export const tradeStatusToFront: Record<TradeRequestStatus, FrontTradeRequestStatus> = {
+  [TradeRequestStatus.PENDING]: 'pending',
+  [TradeRequestStatus.APPROVED]: 'approved',
+  [TradeRequestStatus.REJECTED]: 'rejected',
+};
+
+export const reportTypeToPrisma: Record<FrontReportType, ReportType> = {
+  'schedule-summary': ReportType.SCHEDULE_SUMMARY,
+  'volunteer-status': ReportType.VOLUNTEER_STATUS,
+  'ministry-report': ReportType.MINISTRY_REPORT,
+};
+
+export const reportTypeToFront: Record<ReportType, FrontReportType> = {
+  [ReportType.SCHEDULE_SUMMARY]: 'schedule-summary',
+  [ReportType.VOLUNTEER_STATUS]: 'volunteer-status',
+  [ReportType.MINISTRY_REPORT]: 'ministry-report',
+};
+
+export const userTypeToPrisma: Record<FrontUserType, UserType> = {
+  coordinator: UserType.COORDINATOR,
+  volunteer: UserType.VOLUNTEER,
+};
+
+export const userTypeToFront: Record<UserType, FrontUserType> = {
+  [UserType.COORDINATOR]: 'coordinator',
+  [UserType.VOLUNTEER]: 'volunteer',
+};

--- a/backend/src/validators/ministryValidator.ts
+++ b/backend/src/validators/ministryValidator.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const createMinistrySchema = z.object({
+  name: z.string().min(3),
+  description: z.string().min(3),
+  color: z.string().regex(/^#?[0-9A-Fa-f]{6}$/),
+});
+
+export const updateMinistrySchema = createMinistrySchema.partial();

--- a/backend/src/validators/reportValidator.ts
+++ b/backend/src/validators/reportValidator.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const generateReportSchema = z.object({
+  type: z.enum(['schedule-summary', 'volunteer-status', 'ministry-report']),
+  dateRange: z.object({
+    start: z.string().datetime(),
+    end: z.string().datetime(),
+  }),
+  generatedBy: z.string().uuid(),
+});

--- a/backend/src/validators/scheduleValidator.ts
+++ b/backend/src/validators/scheduleValidator.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+
+export const createScheduleSchema = z.object({
+  date: z.string().datetime().or(z.date()).transform((value) => new Date(value)),
+  time: z.string().min(1),
+  ministryId: z.string().uuid(),
+  volunteerIds: z.array(z.string().uuid()).min(1),
+  createdBy: z.string().uuid(),
+});
+
+export const updateScheduleSchema = z.object({
+  date: z.string().datetime().or(z.date()).transform((value) => new Date(value)).optional(),
+  time: z.string().optional(),
+  ministryId: z.string().uuid().optional(),
+  volunteerIds: z.array(z.string().uuid()).min(1).optional(),
+});
+
+export const updateScheduleStatusSchema = z
+  .object({
+    status: z.enum(['pendente', 'confirmado', 'troca-solicitada']),
+    requestedChangeReason: z.string().min(5).optional(),
+  })
+  .refine(
+    (data) =>
+      data.status !== 'troca-solicitada' || (data.requestedChangeReason && data.requestedChangeReason.length > 0),
+    {
+      message: 'Motivo é obrigatório quando o status é troca-solicitada',
+      path: ['requestedChangeReason'],
+    }
+  );

--- a/backend/src/validators/tradeRequestValidator.ts
+++ b/backend/src/validators/tradeRequestValidator.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+export const createTradeRequestSchema = z.object({
+  scheduleId: z.string().uuid(),
+  requestingVolunteerId: z.string().uuid(),
+  reason: z.string().min(5),
+});
+
+export const updateTradeRequestStatusSchema = z.object({
+  status: z.enum(['pending', 'approved', 'rejected']),
+  respondedBy: z.string().uuid(),
+});

--- a/backend/src/validators/userValidator.ts
+++ b/backend/src/validators/userValidator.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+export const addressSchema = z.object({
+  street: z.string().min(1),
+  number: z.string().min(1),
+  complement: z.string().optional(),
+  neighborhood: z.string().min(1),
+  city: z.string().min(1),
+  state: z.string().min(2).max(2),
+  zipCode: z.string().min(8).max(9),
+});
+
+export const createUserSchema = z.object({
+  name: z.string().min(3),
+  email: z.string().email(),
+  phone: z.string().min(10),
+  cpf: z.string().min(11),
+  rg: z.string().min(5),
+  password: z.string().min(6),
+  userType: z.enum(['coordinator', 'volunteer']),
+  address: addressSchema.optional(),
+  ministries: z.array(z.string()).default([]),
+});
+
+export const updateUserSchema = createUserSchema.partial();

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- compute schedule-level aggregates for ministries, including volunteer status counts and pending trade requests
- add typed helpers to derive ministry overview metrics and include them in the ministry response
- ensure schedule and trade request data are pulled with Prisma so TypeScript strict mode no longer reports implicit any or unknown issues

## Testing
- Not run (dependencies not installed in sandbox)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fbc35bfd08333bf6ce1f435e7ae26)